### PR TITLE
Add multi-node GLB expansion, model loader, quaternion rotation

### DIFF
--- a/crates/flint-ecs/src/world.rs
+++ b/crates/flint-ecs/src/world.rs
@@ -295,11 +295,13 @@ impl FlintWorld {
         let pos = transform_data.get("position").and_then(|v| parse_vec3(v)).unwrap_or(Vec3::ZERO);
         let rot = transform_data.get("rotation").and_then(|v| parse_vec3(v)).unwrap_or(Vec3::ZERO);
         let scale = transform_data.get("scale").and_then(|v| parse_vec3(v)).unwrap_or(Vec3::ONE);
+        let rotation_quat = transform_data.get("rotation_quat").and_then(|v| parse_quat(v));
 
         Some(Transform {
             position: pos,
             rotation: rot,
-            scale: scale,
+            scale,
+            rotation_quat,
         })
     }
 
@@ -325,6 +327,19 @@ impl FlintWorld {
     pub fn entity_names(&self) -> impl Iterator<Item = &str> {
         self.name_map.keys().map(|s| s.as_str())
     }
+}
+
+fn parse_quat(value: &toml::Value) -> Option<[f32; 4]> {
+    if let Some(arr) = value.as_array() {
+        if arr.len() >= 4 {
+            let x = arr[0].as_float().or_else(|| arr[0].as_integer().map(|i| i as f64)).unwrap_or(0.0) as f32;
+            let y = arr[1].as_float().or_else(|| arr[1].as_integer().map(|i| i as f64)).unwrap_or(0.0) as f32;
+            let z = arr[2].as_float().or_else(|| arr[2].as_integer().map(|i| i as f64)).unwrap_or(0.0) as f32;
+            let w = arr[3].as_float().or_else(|| arr[3].as_integer().map(|i| i as f64)).unwrap_or(1.0) as f32;
+            return Some([x, y, z, w]);
+        }
+    }
+    None
 }
 
 fn parse_vec3(value: &toml::Value) -> Option<Vec3> {

--- a/crates/flint-import/src/lib.rs
+++ b/crates/flint-import/src/lib.rs
@@ -9,5 +9,6 @@ mod types;
 pub use gltf_import::import_gltf;
 pub use types::{
     ImportResult, ImportedChannel, ImportedJoint, ImportedKeyframe, ImportedMaterial, ImportedMesh,
-    ImportedSkeleton, ImportedSkeletalClip, ImportedTexture, JointProperty, MeshBounds,
+    ImportedNode, ImportedSkeleton, ImportedSkeletalClip, ImportedTexture, JointProperty,
+    MeshBounds,
 };

--- a/crates/flint-render/src/gpu_mesh.rs
+++ b/crates/flint-render/src/gpu_mesh.rs
@@ -172,6 +172,129 @@ impl MeshCache {
         self.meshes.insert(name.to_string(), gpu_meshes);
     }
 
+    /// Upload a subset of an imported model's meshes to the GPU, identified by mesh indices.
+    /// Used to upload individual node's primitives under a node-specific cache key.
+    /// If `bake_transform` is provided, vertex positions and normals are transformed
+    /// by the given 4x4 column-major matrix before upload (used to flatten hierarchies
+    /// with non-uniform scale during multi-node GLB expansion).
+    pub fn upload_mesh_subset(
+        &mut self,
+        device: &wgpu::Device,
+        name: &str,
+        import_result: &ImportResult,
+        mesh_indices: &[usize],
+        default_color: [f32; 4],
+        bake_transform: Option<&[[f32; 4]; 4]>,
+    ) {
+        // Compute the normal matrix (inverse-transpose of upper-left 3x3) if baking
+        let normal_mat = bake_transform.map(|m| {
+            let a = m[0][0]; let b = m[1][0]; let c = m[2][0];
+            let d = m[0][1]; let e = m[1][1]; let f = m[2][1];
+            let g = m[0][2]; let h = m[1][2]; let i = m[2][2];
+            let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+            let inv_det = if det.abs() > 1e-10 { 1.0 / det } else { 1.0 };
+            // Cofactor matrix rows (= inverse-transpose columns)
+            [
+                [(e * i - f * h) * inv_det, (f * g - d * i) * inv_det, (d * h - e * g) * inv_det],
+                [(c * h - b * i) * inv_det, (a * i - c * g) * inv_det, (b * g - a * h) * inv_det],
+                [(b * f - c * e) * inv_det, (c * d - a * f) * inv_det, (a * e - b * d) * inv_det],
+            ]
+        });
+
+        let default_material = ImportedMaterial {
+            name: "default".to_string(),
+            base_color: default_color,
+            metallic: 0.0,
+            roughness: 0.5,
+            base_color_texture: None,
+            normal_texture: None,
+            metallic_roughness_texture: None,
+            use_vertex_color: false,
+        };
+
+        let gpu_meshes: Vec<GpuMesh> = mesh_indices
+            .iter()
+            .filter_map(|&idx| import_result.meshes.get(idx))
+            .map(|mesh| {
+                let material = mesh
+                    .material_index
+                    .and_then(|i| import_result.materials.get(i))
+                    .cloned()
+                    .unwrap_or_else(|| default_material.clone());
+
+                let vertex_count = mesh.positions.len();
+                let vertices: Vec<Vertex> = (0..vertex_count)
+                    .map(|i| {
+                        let mut position = mesh.positions[i];
+                        let mut normal = if i < mesh.normals.len() {
+                            mesh.normals[i]
+                        } else {
+                            [0.0, 1.0, 0.0]
+                        };
+                        let uv = if i < mesh.uvs.len() {
+                            mesh.uvs[i]
+                        } else {
+                            [0.0, 0.0]
+                        };
+
+                        // Bake transform into vertex data if provided
+                        if let Some(m) = bake_transform {
+                            let [px, py, pz] = position;
+                            position = [
+                                m[0][0] * px + m[1][0] * py + m[2][0] * pz + m[3][0],
+                                m[0][1] * px + m[1][1] * py + m[2][1] * pz + m[3][1],
+                                m[0][2] * px + m[1][2] * py + m[2][2] * pz + m[3][2],
+                            ];
+                        }
+                        if let Some(nm) = &normal_mat {
+                            let [nx, ny, nz] = normal;
+                            let tnx = nm[0][0] * nx + nm[1][0] * ny + nm[2][0] * nz;
+                            let tny = nm[0][1] * nx + nm[1][1] * ny + nm[2][1] * nz;
+                            let tnz = nm[0][2] * nx + nm[1][2] * ny + nm[2][2] * nz;
+                            let len = (tnx * tnx + tny * tny + tnz * tnz).sqrt();
+                            if len > 1e-6 {
+                                normal = [tnx / len, tny / len, tnz / len];
+                            }
+                        }
+
+                        Vertex {
+                            position,
+                            normal,
+                            color: material.base_color,
+                            uv,
+                        }
+                    })
+                    .collect();
+
+                let vertex_data = bytemuck::cast_slice(&vertices).to_vec();
+                let index_data = bytemuck::cast_slice(&mesh.indices).to_vec();
+
+                let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some(&format!("{} Vertex Buffer", name)),
+                    contents: &vertex_data,
+                    usage: wgpu::BufferUsages::VERTEX,
+                });
+
+                let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some(&format!("{} Index Buffer", name)),
+                    contents: &index_data,
+                    usage: wgpu::BufferUsages::INDEX,
+                });
+
+                GpuMesh {
+                    vertex_buffer,
+                    index_buffer,
+                    index_count: mesh.indices.len() as u32,
+                    material,
+                    vertex_data,
+                    index_data,
+                }
+            })
+            .collect();
+
+        self.meshes.insert(name.to_string(), gpu_meshes);
+    }
+
     /// Get cached GPU meshes by asset name
     pub fn get(&self, name: &str) -> Option<&Vec<GpuMesh>> {
         self.meshes.get(name)

--- a/crates/flint-render/src/lib.rs
+++ b/crates/flint-render/src/lib.rs
@@ -11,6 +11,7 @@ mod context;
 mod debug;
 mod gpu_mesh;
 mod headless;
+pub mod model_loader;
 pub mod particle_pipeline;
 mod pipeline;
 pub mod postprocess;

--- a/crates/flint-render/src/model_loader.rs
+++ b/crates/flint-render/src/model_loader.rs
@@ -1,0 +1,500 @@
+//! Shared model and texture loading from ECS world
+//!
+//! Provides [`load_models_from_world`] and [`load_textures_from_world`] that handle
+//! the full pipeline: entity scanning, path resolution, GLB import, multi-node
+//! expansion, skinned mesh detection, and GPU upload.
+//!
+//! Callers can perform skeletal animation registration and catalog pre-resolution
+//! on top of the returned [`ModelLoadResult`].
+
+use flint_core::{mat4_mul, EntityId, Transform, Vec3};
+use flint_ecs::FlintWorld;
+use flint_import::{import_gltf, ImportResult, ImportedNode};
+use crate::SceneRenderer;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Metadata about a single loaded model.
+pub struct LoadedModel {
+    pub entity_id: EntityId,
+    pub asset_name: String,
+    /// The full import result — present only for skinned models that were freshly
+    /// imported (not already cached). Callers use this for skeletal registration.
+    pub import_result: Option<ImportResult>,
+    pub is_skinned: bool,
+    pub was_expanded: bool,
+}
+
+/// Result of loading all models from the world.
+pub struct ModelLoadResult {
+    pub models: Vec<LoadedModel>,
+    /// Entity ID → asset name for entities with skinned meshes.
+    pub skinned_entities: HashMap<EntityId, String>,
+}
+
+/// Configuration for model and texture path resolution.
+pub struct ModelLoadConfig {
+    pub scene_dir: PathBuf,
+    /// Pre-resolved paths for specific asset names (e.g. from catalog lookup).
+    /// Checked before the standard scene_dir/models/ search.
+    pub overrides: HashMap<String, PathBuf>,
+}
+
+impl ModelLoadConfig {
+    /// Create a config from a scene file path, with no overrides.
+    pub fn from_scene_path(scene_path: &str) -> Self {
+        let scene_dir = Path::new(scene_path)
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        Self {
+            scene_dir,
+            overrides: HashMap::new(),
+        }
+    }
+}
+
+/// Convert a quaternion [x, y, z, w] to Euler angles (degrees) in XYZ order.
+pub fn quat_to_euler_xyz(q: [f32; 4]) -> [f32; 3] {
+    let (x, y, z, w) = (q[0], q[1], q[2], q[3]);
+    let sinr_cosp = 2.0 * (w * x + y * z);
+    let cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
+    let roll = sinr_cosp.atan2(cosr_cosp);
+    let sinp = 2.0 * (w * y - z * x);
+    let pitch = if sinp.abs() >= 1.0 {
+        std::f32::consts::FRAC_PI_2.copysign(sinp)
+    } else {
+        sinp.asin()
+    };
+    let siny_cosp = 2.0 * (w * z + x * y);
+    let cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+    let yaw = siny_cosp.atan2(cosy_cosp);
+    [roll.to_degrees(), pitch.to_degrees(), yaw.to_degrees()]
+}
+
+/// Resolve the file path for a model asset name.
+fn resolve_model_path(config: &ModelLoadConfig, asset_name: &str) -> Option<PathBuf> {
+    if let Some(path) = config.overrides.get(asset_name) {
+        if path.exists() {
+            return Some(path.clone());
+        }
+    }
+    let p = config.scene_dir.join("models").join(format!("{}.glb", asset_name));
+    if p.exists() {
+        return Some(p);
+    }
+    if let Some(parent) = config.scene_dir.parent() {
+        let p = parent.join("models").join(format!("{}.glb", asset_name));
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Resolve the file path for a texture name.
+fn resolve_texture_path(config: &ModelLoadConfig, tex_name: &str) -> Option<PathBuf> {
+    if let Some(path) = config.overrides.get(tex_name) {
+        if path.exists() {
+            return Some(path.clone());
+        }
+    }
+    let p = config.scene_dir.join(tex_name);
+    if p.exists() {
+        return Some(p);
+    }
+    if let Some(parent) = config.scene_dir.parent() {
+        let p = parent.join(tex_name);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// Build a 4x4 column-major matrix from a glTF node's TRS.
+fn node_to_matrix(node: &ImportedNode) -> [[f32; 4]; 4] {
+    Transform {
+        position: Vec3::new(node.translation[0], node.translation[1], node.translation[2]),
+        rotation: Vec3::ZERO,
+        scale: Vec3::new(node.scale[0], node.scale[1], node.scale[2]),
+        rotation_quat: Some(node.rotation),
+    }
+    .to_matrix()
+}
+
+/// Compute the accumulated world matrix for every node, recursing from the
+/// given root node indices with `parent_matrix` as the starting transform.
+fn compute_node_world_matrices(
+    import_result: &ImportResult,
+    node_indices: &[usize],
+    parent_matrix: &[[f32; 4]; 4],
+    out: &mut HashMap<usize, [[f32; 4]; 4]>,
+) {
+    for &idx in node_indices {
+        let node = &import_result.nodes[idx];
+        let local = node_to_matrix(node);
+        let world = mat4_mul(parent_matrix, &local);
+        out.insert(idx, world);
+        if !node.children.is_empty() {
+            compute_node_world_matrices(import_result, &node.children, &world, out);
+        }
+    }
+}
+
+/// Create flat child entities for every mesh-bearing node in the glTF tree.
+///
+/// Unlike a naive hierarchy mirror, this bakes each node's accumulated world
+/// transform into the GPU vertex data at upload time, then stores an identity
+/// transform on the entity. This eliminates visual distortion from non-uniform
+/// parent scales, which is common in Blender exports.
+fn expand_nodes_flat(
+    world: &mut FlintWorld,
+    import_result: &ImportResult,
+    node_indices: &[usize],
+    parent_entity_id: EntityId,
+    parent_entity_name: &str,
+    asset_name: &str,
+    renderer: &mut SceneRenderer,
+    device: &wgpu::Device,
+) {
+    // Pre-compute world matrices for every node in the tree
+    let identity = Transform::IDENTITY.to_matrix();
+    let mut world_matrices = HashMap::new();
+    compute_node_world_matrices(import_result, node_indices, &identity, &mut world_matrices);
+
+    // Walk the full tree and create a flat entity for each mesh-bearing node
+    let mut stack: Vec<(usize, String)> = node_indices
+        .iter()
+        .rev()
+        .map(|&idx| (idx, parent_entity_name.to_string()))
+        .collect();
+
+    let default_color = [0.5_f32, 0.5, 0.5, 1.0];
+
+    while let Some((node_idx, parent_name)) = stack.pop() {
+        let node = &import_result.nodes[node_idx];
+        let child_name = format!("{}__{}", parent_name, node.name);
+
+        if !node.mesh_primitive_indices.is_empty() {
+            let child_id = match world.spawn(&child_name) {
+                Ok(id) => id,
+                Err(e) => {
+                    eprintln!("Failed to spawn child entity '{}': {:?}", child_name, e);
+                    // Still push children for further traversal
+                    for &c in node.children.iter().rev() {
+                        stack.push((c, child_name.clone()));
+                    }
+                    continue;
+                }
+            };
+
+            // Identity transform — geometry is already in GLB root space
+            let transform = toml::Value::Table({
+                let mut t = toml::map::Map::new();
+                t.insert(
+                    "position".to_string(),
+                    toml::Value::Array(vec![
+                        toml::Value::Float(0.0),
+                        toml::Value::Float(0.0),
+                        toml::Value::Float(0.0),
+                    ]),
+                );
+                t
+            });
+            let _ = world.set_component(child_id, "transform", transform);
+
+            // Upload mesh with baked world transform
+            let cache_key = format!("{}/{}", asset_name, node.name);
+            let world_mat = world_matrices.get(&node_idx).unwrap_or(&identity);
+            renderer.mesh_cache_mut().upload_mesh_subset(
+                device,
+                &cache_key,
+                import_result,
+                &node.mesh_primitive_indices,
+                default_color,
+                Some(world_mat),
+            );
+
+            let model = toml::Value::Table({
+                let mut m = toml::map::Map::new();
+                m.insert("asset".to_string(), toml::Value::String(cache_key));
+                m
+            });
+            let _ = world.set_component(child_id, "model", model);
+
+            // All mesh entities parent directly to the root entity
+            let _ = world.set_parent(child_id, parent_entity_id);
+            println!("  Expanded node: {} (flat, baked transform)", child_name);
+        }
+
+        // Push children for traversal (non-mesh nodes are traversed but not spawned)
+        for &c in node.children.iter().rev() {
+            stack.push((c, child_name.clone()));
+        }
+    }
+}
+
+/// Load all models referenced by entities in the world.
+///
+/// Handles path resolution, GLB import, multi-node expansion, skinned mesh
+/// detection, and GPU upload. Returns metadata so callers can perform
+/// skeletal animation registration on top.
+pub fn load_models_from_world(
+    world: &mut FlintWorld,
+    renderer: &mut SceneRenderer,
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    config: &ModelLoadConfig,
+) -> ModelLoadResult {
+    let mut result = ModelLoadResult {
+        models: Vec::new(),
+        skinned_entities: HashMap::new(),
+    };
+
+    // Pass 1: Collect entity-model pairs (can't mutate world while iterating)
+    let entity_models: Vec<(EntityId, String, String)> = world
+        .all_entities()
+        .iter()
+        .filter_map(|e| {
+            let model_asset = world
+                .get_components(e.id)
+                .and_then(|components| components.get("model").cloned())
+                .and_then(|model| model.get("asset").and_then(|v| v.as_str().map(String::from)));
+            model_asset.map(|asset| (e.id, e.name.clone(), asset))
+        })
+        .collect();
+
+    // Cache import results for multi-node GLBs so subsequent entities
+    // referencing the same asset can be expanded into their own children.
+    let mut expansion_cache: HashMap<String, ImportResult> = HashMap::new();
+
+    // Pass 2: Load and expand
+    for (entity_id, entity_name, asset_name) in &entity_models {
+        if renderer.mesh_cache().contains(asset_name) {
+            // If this asset was previously expanded (same load call), expand for this entity too
+            if let Some(cached_import) = expansion_cache.get(asset_name.as_str()) {
+                expand_nodes_flat(
+                    world,
+                    cached_import,
+                    &cached_import.root_nodes,
+                    *entity_id,
+                    entity_name,
+                    asset_name,
+                    renderer,
+                    device,
+                );
+                if let Some(components) = world.get_components_mut(*entity_id) {
+                    components.remove("model");
+                }
+                result.models.push(LoadedModel {
+                    entity_id: *entity_id,
+                    asset_name: asset_name.clone(),
+                    import_result: None,
+                    is_skinned: false,
+                    was_expanded: true,
+                });
+                continue;
+            }
+
+            // Mesh cached from a previous scene/load — re-import to check
+            // if this is a multi-node model that needs per-entity expansion.
+            if let Some(model_path) = resolve_model_path(config, asset_name) {
+                if let Ok(import_result) = import_gltf(&model_path) {
+                    if import_result.needs_expansion() {
+                        expand_nodes_flat(
+                            world,
+                            &import_result,
+                            &import_result.root_nodes,
+                            *entity_id,
+                            entity_name,
+                            asset_name,
+                            renderer,
+                            device,
+                        );
+                        if let Some(components) = world.get_components_mut(*entity_id) {
+                            components.remove("model");
+                        }
+                        result.models.push(LoadedModel {
+                            entity_id: *entity_id,
+                            asset_name: asset_name.clone(),
+                            import_result: None,
+                            is_skinned: false,
+                            was_expanded: true,
+                        });
+                        expansion_cache.insert(asset_name.clone(), import_result);
+                        continue;
+                    }
+                }
+            }
+
+            if renderer.mesh_cache().contains_skinned(asset_name) {
+                result.skinned_entities.insert(*entity_id, asset_name.clone());
+                result.models.push(LoadedModel {
+                    entity_id: *entity_id,
+                    asset_name: asset_name.clone(),
+                    import_result: None,
+                    is_skinned: true,
+                    was_expanded: false,
+                });
+            }
+            continue;
+        }
+
+        let model_path = match resolve_model_path(config, asset_name) {
+            Some(p) => p,
+            None => {
+                eprintln!("Model file not found: {}", asset_name);
+                continue;
+            }
+        };
+
+        match import_gltf(&model_path) {
+            Ok(import_result) => {
+                let has_skins = !import_result.skeletons.is_empty();
+                let has_skinned_meshes = import_result
+                    .meshes
+                    .iter()
+                    .any(|m| m.joint_indices.is_some());
+                let is_skinned = has_skinned_meshes && has_skins;
+
+                let bounds_info = import_result
+                    .bounds()
+                    .map(|b| format!(", bounds: {}", b))
+                    .unwrap_or_default();
+
+                println!(
+                    "Loaded model: {} ({} meshes, {} nodes{}{})",
+                    asset_name,
+                    import_result.meshes.len(),
+                    import_result.nodes.len(),
+                    if has_skins {
+                        format!(
+                            ", {} skins, {} skeletal clips",
+                            import_result.skeletons.len(),
+                            import_result.skeletal_clips.len()
+                        )
+                    } else {
+                        String::new()
+                    },
+                    bounds_info,
+                );
+
+                let was_expanded;
+                let kept_result;
+
+                if is_skinned {
+                    renderer.load_skinned_model(device, queue, asset_name, &import_result);
+                    renderer.load_model(device, queue, asset_name, &import_result);
+                    result.skinned_entities.insert(*entity_id, asset_name.clone());
+                    was_expanded = false;
+                    kept_result = Some(import_result);
+                } else if import_result.needs_expansion() {
+                    // Use the whole-model upload for any code paths that look
+                    // up the asset by its base name (e.g. bounds queries).
+                    renderer.load_model(device, queue, asset_name, &import_result);
+
+                    // Flatten the glTF node hierarchy: bake each node's
+                    // accumulated world transform into vertex data so entities
+                    // can use identity transforms. This avoids visual distortion
+                    // from non-uniform parent scales in the glTF tree.
+                    expand_nodes_flat(
+                        world,
+                        &import_result,
+                        &import_result.root_nodes,
+                        *entity_id,
+                        entity_name,
+                        asset_name,
+                        renderer,
+                        device,
+                    );
+
+                    if let Some(components) = world.get_components_mut(*entity_id) {
+                        components.remove("model");
+                    }
+
+                    // Cache for subsequent entities referencing the same asset
+                    expansion_cache.insert(asset_name.clone(), import_result);
+                    was_expanded = true;
+                    kept_result = None;
+                } else {
+                    renderer.load_model(device, queue, asset_name, &import_result);
+                    was_expanded = false;
+                    kept_result = None;
+                }
+
+                result.models.push(LoadedModel {
+                    entity_id: *entity_id,
+                    asset_name: asset_name.clone(),
+                    import_result: kept_result,
+                    is_skinned,
+                    was_expanded,
+                });
+            }
+            Err(e) => {
+                eprintln!("Failed to load model '{}': {:?}", asset_name, e);
+            }
+        }
+    }
+
+    // Load textures
+    load_textures_from_world(world, renderer, device, queue, config);
+
+    result
+}
+
+/// Load texture files referenced by material and sprite components.
+pub fn load_textures_from_world(
+    world: &FlintWorld,
+    renderer: &mut SceneRenderer,
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    config: &ModelLoadConfig,
+) {
+    let mut loaded = std::collections::HashSet::new();
+
+    for entity in world.all_entities() {
+        let components = world.get_components(entity.id);
+        let mut tex_names = Vec::new();
+
+        if let Some(comps) = &components {
+            if let Some(material) = comps.get("material") {
+                if let Some(tex) = material.get("texture").and_then(|v| v.as_str()) {
+                    tex_names.push(tex.to_string());
+                }
+            }
+            if let Some(sprite) = comps.get("sprite") {
+                if let Some(tex) = sprite.get("texture").and_then(|v| v.as_str()) {
+                    if !tex.is_empty() {
+                        tex_names.push(tex.to_string());
+                    }
+                }
+            }
+        }
+
+        for tex_name in tex_names {
+            if loaded.contains(&tex_name) {
+                continue;
+            }
+            loaded.insert(tex_name.clone());
+
+            let tex_path = match resolve_texture_path(config, &tex_name) {
+                Some(p) => p,
+                None => {
+                    eprintln!("Texture file not found: {}", tex_name);
+                    continue;
+                }
+            };
+
+            match renderer.load_texture_file(device, queue, &tex_name, &tex_path) {
+                Ok(true) => {
+                    println!("Loaded texture: {}", tex_name);
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    eprintln!("Failed to load texture '{}': {}", tex_name, e);
+                }
+            }
+        }
+    }
+}

--- a/crates/flint-render/src/scene_renderer.rs
+++ b/crates/flint-render/src/scene_renderer.rs
@@ -914,20 +914,27 @@ impl SceneRenderer {
                         let (mr_view, mr_sampler, has_mr) =
                             Self::resolve_texture(tex_cache_ref, gpu_mesh.material.metallic_roughness_texture.as_deref(), &tex_cache_ref.default_metallic_roughness);
 
-                        let base_color = if let Some(override_color) = world
+                        // Material color override: check entity first, then inherit from parent.
+                        // This lets scripts color a parent entity and have all child meshes
+                        // (e.g. expanded GLB nodes) pick up the tint automatically.
+                        let extract_color = |m: &toml::Value| -> Option<[f32; 4]> {
+                            let r = m.get("base_color_r")?.as_float()? as f32;
+                            let g = m.get("base_color_g")?.as_float()? as f32;
+                            let b = m.get("base_color_b")?.as_float()? as f32;
+                            let a = m.get("base_color_a").and_then(|v| v.as_float()).unwrap_or(1.0) as f32;
+                            Some([r, g, b, a])
+                        };
+                        let base_color = world
                             .get_components(entity.id)
                             .and_then(|c| c.get("material"))
-                            .and_then(|m| {
-                                let r = m.get("base_color_r")?.as_float()? as f32;
-                                let g = m.get("base_color_g")?.as_float()? as f32;
-                                let b = m.get("base_color_b")?.as_float()? as f32;
-                                let a = m.get("base_color_a").and_then(|v| v.as_float()).unwrap_or(1.0) as f32;
-                                Some([r, g, b, a])
-                            }) {
-                            override_color
-                        } else {
-                            gpu_mesh.material.base_color
-                        };
+                            .and_then(|m| extract_color(m))
+                            .or_else(|| {
+                                world.get_parent(entity.id)
+                                    .and_then(|pid| world.get_components(pid))
+                                    .and_then(|c| c.get("material"))
+                                    .and_then(|m| extract_color(m))
+                            })
+                            .unwrap_or(gpu_mesh.material.base_color);
 
                         let mut material_uniforms = MaterialUniforms::from_pbr(
                             base_color,
@@ -1138,13 +1145,14 @@ impl SceneRenderer {
                 }
             }
 
-            // Only draw fallback geometry for entities that explicitly have bounds or material.
-            // Entities without a model, bounds, or material are non-visual (lights, scripts,
-            // particle emitters, splines, etc.) and should not get a default cube.
+            // Only draw fallback geometry for entities that explicitly have bounds.
+            // A `material` component alone does not create geometry — it only modifies
+            // the appearance of existing geometry (bounds box or model mesh).
+            // Entities without a model or bounds are non-visual (lights, scripts,
+            // particle emitters, expanded GLB parents, etc.).
             if let Some(components) = world.get_components(entity.id) {
                 let has_bounds = components.get("bounds").is_some();
-                let has_material = components.get("material").is_some();
-                if !has_bounds && !has_material {
+                if !has_bounds {
                     continue;
                 }
             }

--- a/crates/flint-script/src/api.rs
+++ b/crates/flint-script/src/api.rs
@@ -210,6 +210,12 @@ fn register_entity_api(engine: &mut Engine, ctx: Arc<Mutex<ScriptCallContext>>) 
                     toml::Value::Float(y),
                     toml::Value::Float(z),
                 ]));
+                // Clear quaternion so Euler angles take effect
+                if let Some(transform) = comps.get_mut("transform") {
+                    if let Some(table) = transform.as_table_mut() {
+                        table.remove("rotation_quat");
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- Extract duplicated model/texture loading into reusable `model_loader` module (replaces copy-paste across render, serve, player, and viewer commands)
- glTF importer now walks the scene graph per-node preserving transforms and hierarchy, enabling multi-node GLBs to auto-expand into child entities with `{parent}__{node_name}` naming
- Add `rotation_quat` field to Transform for gimbal-lock-free rotations from glTF quaternion data
- `MeshCache::upload_mesh_subset()` with optional transform baking for flattening non-uniform-scale hierarchies

## Test plan
- [ ] `flint render` with multi-node GLB models produces correct child entity expansion
- [ ] Single-mesh GLBs continue to work unchanged (no regression)
- [ ] Skinned meshes skip expansion as expected
- [ ] `set_rotation()` clears quaternion so Euler angles take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)